### PR TITLE
updated navbar to indicate admin, volunteer or not logged in

### DIFF
--- a/inventory/templates/inventory/_navbar.html
+++ b/inventory/templates/inventory/_navbar.html
@@ -7,7 +7,7 @@
 			{% load static %}
 			<img src="{% static 'inventory/logo.png' %}" width="35" height="33" class="d-inline-block align-top" alt="FLP Logo">
 			{% if user.is_staff %}
-			<b>&nbsp;&nbsp;Foster Love Project (Admin)&nbsp;&nbsp;</b>
+			<b style="color:yellow;">&nbsp;&nbsp;Foster Love Project (Admin)&nbsp;&nbsp;</b>
 			{% elif user.is_authenticated %}
 			<b>&nbsp;&nbsp;Foster Love Project (Volunteer)&nbsp;&nbsp;</b>
 			{% else %}


### PR DESCRIPTION
I updated _navbar.html so the icon title displays differently to indicate whether the user is admin, volunteer or not logged in. I used user.is_staff and user.isauthenticated in if else statements to make the distinction.

Logged in using the admin / admin account 
![image](https://user-images.githubusercontent.com/51033749/113088582-c3bf0900-919a-11eb-9122-5db500f84363.png)

Logged in using an account I just registered 
![image](https://user-images.githubusercontent.com/51033749/113088623-db968d00-919a-11eb-9f85-2a03d78ba25d.png)

Not Logged in
![image](https://user-images.githubusercontent.com/51033749/113088639-e3563180-919a-11eb-9c04-eb1457b48b63.png)
