### PR TITLE
Disable sorting for in_items, out_items

### DIFF
--- a/inventory/models.py
+++ b/inventory/models.py
@@ -50,6 +50,8 @@ class Checkin(models.Model):
 
   def __str__(self):
     return "({}, {})".format(self.datetime, self.in_items())
+
+  @property
   def in_items(self):
         return ", ".join([str(i) for i in self.items.all()])
   
@@ -71,6 +73,7 @@ class Checkout(models.Model):
   def __str__(self):
     return "({}, {})".format(self.family, self.out_items())
   
+  @property
   def out_items(self):
         return ", ".join([str(i) for i in self.items.all()])
   

--- a/inventory/tables.py
+++ b/inventory/tables.py
@@ -35,6 +35,7 @@ class ItemTable(NameTable):
         order_by = 'name'
 
 class CheckinTable(tables.Table):   
+    in_items = tables.Column(accessor='in_items', orderable=False)
     class Meta:
         model = Checkin
         template_name = "django_tables2/bootstrap.html"
@@ -42,6 +43,7 @@ class CheckinTable(tables.Table):
         order_by = '-datetime'
 
 class CheckoutTable(tables.Table):
+    out_items = tables.Column(accessor='out_items', orderable=False)
     class Meta:
         model = Checkout
         template_name = "django_tables2/bootstrap.html"


### PR DESCRIPTION
I tried for a really long time to enable sorting on the foreign key items fields but then realized I'm the mayor of clown town and it doesn't make sense to sort them at all so I disabled it.

![image](https://user-images.githubusercontent.com/34123199/113225050-bb2e0780-925a-11eb-8d88-22dace4a51b9.png)


![image](https://user-images.githubusercontent.com/34123199/113225023-ae111880-925a-11eb-8244-4ce02157de42.png)