### PR TITLE
Family Index: Update display names to be more user friendly

### DIFF
--- a/inventory/models.py
+++ b/inventory/models.py
@@ -16,7 +16,7 @@ class Family(models.Model):
   # USE Family.child_set OR .children TO GET QuerySet<Child>
 
   @property
-  def childNames(self):
+  def child_names(self):
     return ','.join(map(lambda c: c.name, self.children.all()))
   
   def __str__(self):

--- a/inventory/tables.py
+++ b/inventory/tables.py
@@ -14,12 +14,12 @@ class NameTable(tables.Table):
         return (queryset, True)
 
 class FamilyTable(tables.Table):
-    childNames = tables.Column('childNames')
+    child_names = tables.Column(accessor='child_names', orderable=False)
 
     class Meta:
         model = Family
         template_name = "django_tables2/bootstrap.html"
-        sequence = "id", "lname", "fname", "phone", "childNames"
+        sequence = "id", "lname", "fname", "phone", "child_names"
         order_by = 'lname'
 
 class CategoryTable(NameTable):


### PR DESCRIPTION
Change fields like fname and lname to be First Name and Last Name. Changed childNames to be _Child Names_ for consistency.

![image](https://user-images.githubusercontent.com/34123199/114962717-3a196780-9e39-11eb-8e95-39ca245f3fd3.png)

Also fix a bug when sorting by child names by disabling it since it doesn't make sense with multiple children.