### PR TITLE
Item search

### DIFF
--- a/inventory/filters.py
+++ b/inventory/filters.py
@@ -2,7 +2,7 @@ import django_filters
 from .models import Checkout, Item
 
 class CheckoutFilter(django_filters.FilterSet):
-    family__displayName = django_filters.CharFilter(lookup_expr='iexact')
+    family__displayName = django_filters.CharFilter(lookup_expr='icontains')
 
     class Meta:
         model = Checkout

--- a/inventory/filters.py
+++ b/inventory/filters.py
@@ -9,8 +9,8 @@ class CheckoutFilter(django_filters.FilterSet):
         fields = ['family__displayName']
 
 class ItemFilter(django_filters.FilterSet):
-    item__name = django_filters.CharFilter(lookup_expr='iexact')
+    name = django_filters.CharFilter(lookup_expr='icontains')
 
     class Meta:
         model = Item
-        fields = ['item__name']
+        fields = ['name']

--- a/inventory/filters.py
+++ b/inventory/filters.py
@@ -1,5 +1,5 @@
 import django_filters
-from .models import Checkout
+from .models import Checkout, Item
 
 class CheckoutFilter(django_filters.FilterSet):
     family__displayName = django_filters.CharFilter(lookup_expr='iexact')
@@ -7,3 +7,10 @@ class CheckoutFilter(django_filters.FilterSet):
     class Meta:
         model = Checkout
         fields = ['family__displayName']
+
+class ItemFilter(django_filters.FilterSet):
+    item__name = django_filters.CharFilter(lookup_expr='iexact')
+
+    class Meta:
+        model = Item
+        fields = ['item__name']

--- a/inventory/templates/inventory/items/index.html
+++ b/inventory/templates/inventory/items/index.html
@@ -23,7 +23,45 @@
       </div>
     {% endif %}
   </div>
-
+  <form action="" method="get" class="form form-inline">
+    <div class="row">
+      <div class="col">
+        <div class="form-group">
+          <input 
+            type="text" name="item__name" class="form-control ui-autocomplete-input" placeholder="Item name" title="" id="id_item__name" autocomplete="off">
+        </div>
+      </div>
+      <div class="col filter-button-container">
+        <button class="btn btn-primary">Filter</button>
+      </div>
+    </div>
+  </form>
   {% render_table table %}
 </div>
+{% endblock %}
+
+{% block page_specific_scripts %}
+<script>
+  $(document).ready(function() {
+    $("#id_item__name").autocomplete({
+      source: '{% url "autocomplete_item" %}',
+      minLength: 2
+    });
+
+    $("#id_item__name").val(function () {
+      return localStorage.getItem("item-filter");
+    });
+    $("#id_item__name").on("change", function () {
+      localStorage.setItem("item-filter", $(this).val());
+    });
+    $("#id_item__name").on("click", function () {
+      $(this).val("");
+      localStorage.setItem("item-filter", $(this).val());
+    });
+    $("#id_item").autocomplete({
+      source: '{% url "autocomplete_item" %}',
+      minLength: 2
+    });
+  });
+</script>
 {% endblock %}

--- a/inventory/templates/inventory/items/index.html
+++ b/inventory/templates/inventory/items/index.html
@@ -28,7 +28,7 @@
       <div class="col">
         <div class="form-group">
           <input 
-            type="text" name="item__name" class="form-control ui-autocomplete-input" placeholder="Item name" title="" id="id_item__name" autocomplete="off">
+            type="text" name="name" class="form-control ui-autocomplete-input" placeholder="Item name" title="" id="id_name" autocomplete="off">
         </div>
       </div>
       <div class="col filter-button-container">
@@ -43,24 +43,20 @@
 {% block page_specific_scripts %}
 <script>
   $(document).ready(function() {
-    $("#id_item__name").autocomplete({
+    $("#id_name").autocomplete({
       source: '{% url "autocomplete_item" %}',
       minLength: 2
     });
 
-    $("#id_item__name").val(function () {
+    $("#id_name").val(function () {
       return localStorage.getItem("item-filter");
     });
-    $("#id_item__name").on("change", function () {
+    $("#id_name").on("change", function () {
       localStorage.setItem("item-filter", $(this).val());
     });
-    $("#id_item__name").on("click", function () {
+    $("#id_name").on("click", function () {
       $(this).val("");
       localStorage.setItem("item-filter", $(this).val());
-    });
-    $("#id_item").autocomplete({
-      source: '{% url "autocomplete_item" %}',
-      minLength: 2
     });
   });
 </script>

--- a/inventory/views.py
+++ b/inventory/views.py
@@ -5,7 +5,7 @@ from django.core import serializers
 from django.http import JsonResponse
 from django_tables2 import SingleTableView, SingleTableMixin
 from django_filters.views import FilterView
-from .filters import CheckoutFilter
+from .filters import CheckoutFilter, ItemFilter
 from .tables import FamilyTable, CategoryTable, ItemTable, CheckinTable, CheckoutTable
 
 from django.contrib import messages
@@ -656,10 +656,11 @@ class CategoryIndexView(LoginRequiredMixin, SingleTableView):
     table_class = CategoryTable
     template_name = "inventory/categories/index.html"
 
-class ItemIndexView(LoginRequiredMixin, SingleTableView):
+class ItemIndexView(LoginRequiredMixin, SingleTableMixin, FilterView):
     model = Item
     table_class = ItemTable
     template_name = "inventory/items/index.html"
+    filterset_class = ItemFilter
 
 class CheckinIndexView(LoginRequiredMixin, SingleTableView):
     model = Checkin


### PR DESCRIPTION
Their actual data has way too many items to find a single item so I made a filter similar to checkouts index to search for an item.

Autcomplete
![image](https://user-images.githubusercontent.com/34123199/121469908-4e866600-c98b-11eb-8c91-885502e85d54.png)

Filter by contains
![image](https://user-images.githubusercontent.com/34123199/121469915-52b28380-c98b-11eb-902b-faf4be42ab73.png)

I realized that we currently filter checkouts by exact family display name. Is there a reason we cant just do whether it contains the search string? I changed it to icontains and I'm hoping it doesn't affect anything else but lmk if it does.

Filter checkouts by contains
![image](https://user-images.githubusercontent.com/34123199/121469970-6f4ebb80-c98b-11eb-8567-f8041e1f8a4c.png)